### PR TITLE
 feat(worker/args): add basic command-line args parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +118,52 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation-sys"
@@ -138,6 +232,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -326,6 +426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +545,15 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
@@ -498,6 +619,7 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 name = "worker"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "eyre",
  "proto",
  "sysinfo",

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Tucano
+
+An educational service scheduler and load balancer.
+
+_(WIP - improve README.)_
+
+## Running locally
+
+Controller:
+
+```
+cargo run -p ctl
+```
+
+Worker:
+
+```
+cargo run -p worker -- --controller-addr '127.0.0.1:3000'
+```

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+clap.workspace = true
 eyre.workspace = true
 proto.workspace = true
 sysinfo.workspace = true

--- a/worker/src/args.rs
+++ b/worker/src/args.rs
@@ -1,0 +1,41 @@
+use std::{net::SocketAddr, time::Duration};
+
+use clap::{value_parser, Parser};
+
+pub struct WorkerArgs {
+    /// Controller's address.
+    pub controller_addr: SocketAddr,
+
+    /// Interval at which metrics are pushed to the controller.
+    pub metrics_report_interval: Duration,
+}
+
+impl WorkerArgs {
+    /// Parses the process arguments and returns a new [`Args`].
+    ///
+    /// Panics if missing arguments or if arguments are invalid.
+    pub fn parse() -> Self {
+        let raw = RawWorkerArgs::parse();
+        WorkerArgs {
+            controller_addr: raw.controller_addr,
+            metrics_report_interval: Duration::from_secs(raw.metrics_report_interval.into()),
+        }
+    }
+}
+
+#[derive(Parser)]
+struct RawWorkerArgs {
+    /// Controller's HTTP address.
+    #[arg(short, long)]
+    controller_addr: SocketAddr,
+
+    /// Interval at which metrics are pushed to the controller.
+    ///
+    /// Time in seconds. Must be greater than 1.
+    #[arg(
+        long,
+        default_value = "5",
+        value_parser = value_parser!(u32).range(1..)
+    )]
+    metrics_report_interval: u32,
+}

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -1,20 +1,19 @@
 use eyre::Result;
-use tokio::time::{sleep, Duration};
+use tokio::time::sleep;
 
-use crate::monitor::collector::MetricsCollector;
+use crate::{args::WorkerArgs, monitor::collector::MetricsCollector};
 
-pub mod monitor;
-
-/// `clap` crate report interval placeholder
-/// The value 500 is for quick visualization purposes.
-const REPORT_INTERVAL_IN_MILLIS: u64 = 500;
+mod args;
+mod monitor;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args = WorkerArgs::parse();
+
     let mut metrics_report: MetricsCollector = MetricsCollector::new();
 
     loop {
-        sleep(Duration::from_millis(REPORT_INTERVAL_IN_MILLIS)).await;
+        sleep(args.metrics_report_interval).await;
         let metrics = metrics_report.get_metrics();
         println!("{metrics:#?}");
     }


### PR DESCRIPTION
`cargo run -p worker -- --help` example output:

```text
$ cargo run -p worker -- --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/worker --help`
Usage: worker [OPTIONS] --controller-addr <CONTROLLER_ADDR>

Options:
  -c, --controller-addr <CONTROLLER_ADDR>
          Controller's HTTP address

      --metrics-report-interval <METRICS_REPORT_INTERVAL>
          Interval at which metrics are pushed to the controller.
          
          Time in seconds. Must be greater than 1.
          
          [default: 5]

  -h, --help
          Print help (see a summary with '-h')
```