### PR TITLE
feat(worker): messsage handling

### DIFF
--- a/proto/src/common/instance.rs
+++ b/proto/src/common/instance.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -5,6 +7,12 @@ use crate::common::service::{ResourceConfig, ServiceImage};
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct InstanceId(pub Uuid);
+
+impl fmt::Display for InstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InstanceSpec {

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -12,6 +12,7 @@ mod args;
 mod http;
 mod monitor;
 mod runner;
+mod sender;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -20,15 +21,18 @@ async fn main() -> Result<()> {
     let args = Arc::new(WorkerArgs::parse());
     info!(?args, "started worker");
 
+    let sender = sender::Sender::new(args.controller_addr);
+
     let pusher_handle = tokio::spawn({
         let args = Arc::clone(&args);
+        let sender = Arc::clone(&sender);
         async move {
-            pusher::start_pusher(args).await;
+            pusher::start_pusher(args, sender).await;
         }
     });
 
     let docker = Arc::new(Docker::connect_with_http_defaults().unwrap());
-    let (runner, runner_handle) = Runner::new(docker);
+    let (runner, runner_handle) = Runner::new(docker, sender);
     let runner_actor_handle = tokio::spawn(async move {
         runner.run().await;
     });

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     let args = Arc::new(WorkerArgs::parse());
     info!(?args, "started worker");
 
-    let sender = sender::Sender::new(args.controller_addr);
+    let sender = Arc::new(sender::Sender::new(args.controller_addr));
 
     let pusher_handle = tokio::spawn({
         let args = Arc::clone(&args);

--- a/worker/src/monitor/pusher.rs
+++ b/worker/src/monitor/pusher.rs
@@ -1,23 +1,14 @@
 use std::sync::Arc;
 
-use reqwest;
 use tokio::time::sleep;
 
-use crate::{args::WorkerArgs, monitor::collector::MetricsCollector};
+use crate::{args::WorkerArgs, monitor::collector::MetricsCollector, sender};
 
-pub async fn start_pusher(args: Arc<WorkerArgs>) {
+pub async fn start_pusher(args: Arc<WorkerArgs>, sender: Arc<sender::Sender>) {
     let mut metrics_report: MetricsCollector = MetricsCollector::new();
-
-    let client = reqwest::Client::new();
-
     loop {
         sleep(args.metrics_report_interval).await;
         let metrics = metrics_report.get_metrics();
-
-        let _ = client
-            .post("http://localhost:3000/worker/metrics")
-            .json(&metrics)
-            .send()
-            .await;
+        let _ = sender.send_metrics(metrics).await;
     }
 }

--- a/worker/src/monitor/pusher.rs
+++ b/worker/src/monitor/pusher.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use tokio::time::sleep;
+use tracing::error;
 
 use crate::{args::WorkerArgs, monitor::collector::MetricsCollector, sender};
 
@@ -9,6 +10,9 @@ pub async fn start_pusher(args: Arc<WorkerArgs>, sender: Arc<sender::Sender>) {
     loop {
         sleep(args.metrics_report_interval).await;
         let metrics = metrics_report.get_metrics();
-        let _ = sender.send_metrics(metrics).await;
+        match sender.send_metrics(metrics).await {
+            Ok(()) => {}
+            Err(e) => error!("Failed to send metrics: {e}"),
+        };
     }
 }

--- a/worker/src/sender/mod.rs
+++ b/worker/src/sender/mod.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::net::SocketAddr;
 
 use proto::common::{
     instance::{self, InstanceId},
@@ -11,28 +11,30 @@ use reqwest::Client;
 #[derive(Clone, Debug)]
 pub struct Sender {
     pub client: Client,
-    pub http_path: SocketAddr,
+
+    /// The `ctl::http` URL should be known by the worker since the start.
+    /// So it should be passed via `args` to the main function.
+    pub ctl_path: SocketAddr,
 }
 
 impl Sender {
     /// Creates a `Sender` instance wrapped by an `Arc`.
     #[must_use]
-    pub fn new(path: SocketAddr) -> Arc<Self> {
-        Arc::new(Sender {
+    pub fn new(path: SocketAddr) -> Self {
+        Sender {
             client: Client::new(),
-            http_path: path,
-        })
+            ctl_path: path,
+        }
     }
-    /// The `ctl::http` URL should be known by the worker since the start.
-    /// So it should be passed via `args` to the main function.  
+
     pub async fn send_status(&self, id: InstanceId, status: instance::Status) -> eyre::Result<()> {
-        let path = format!("{:?}/deploy/status", self.http_path);
+        let path = format!("{:?}/deploy/status", self.ctl_path);
         let _ = self.client.post(path).json(&(&id, &status)).send().await?;
         Ok(())
     }
 
     pub async fn send_metrics(&self, metrics: Metrics) -> eyre::Result<()> {
-        let path = format!("{:?}/worker/metrics", self.http_path);
+        let path = format!("{:?}/worker/metrics", self.ctl_path);
         let _ = self.client.post(path).json(&metrics).send().await?;
         Ok(())
     }

--- a/worker/src/sender/mod.rs
+++ b/worker/src/sender/mod.rs
@@ -1,0 +1,39 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use proto::common::{
+    instance::{self, InstanceId},
+    node::Metrics,
+};
+use reqwest::Client;
+
+/// Sends a http request to `ctl::http` component with body
+/// containing `instance::Status` information used in `ctl::discovery`
+#[derive(Clone, Debug)]
+pub struct Sender {
+    pub client: Client,
+    pub http_path: SocketAddr,
+}
+
+impl Sender {
+    /// Creates a `Sender` instance wrapped by an `Arc`.
+    #[must_use]
+    pub fn new(path: SocketAddr) -> Arc<Self> {
+        Arc::new(Sender {
+            client: Client::new(),
+            http_path: path,
+        })
+    }
+    /// The `ctl::http` URL should be known by the worker since the start.
+    /// So it should be passed via `args` to the main function.  
+    pub async fn send_status(&self, id: InstanceId, status: instance::Status) -> eyre::Result<()> {
+        let path = format!("{:?}/deploy/status", self.http_path);
+        let _ = self.client.post(path).json(&(&id, &status)).send().await?;
+        Ok(())
+    }
+
+    pub async fn send_metrics(&self, metrics: Metrics) -> eyre::Result<()> {
+        let path = format!("{:?}/worker/metrics", self.http_path);
+        let _ = self.client.post(path).json(&metrics).send().await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
In this PR:
* Implemented `Sender` struct, responsible for making HTTP requests to `ctl::http` component.
* Implemented instance termination with shutdown.
* Refactored worker's main, `Runner` and `ContainerRuntime` 