### PR TITLE
feat(worker/http): complete http runner routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,9 @@ dependencies = [
 name = "setup"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "eyre",
+ "serde_json",
  "tracing-subscriber",
 ]
 

--- a/crates/setup/Cargo.toml
+++ b/crates/setup/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+axum.workspace = true
+eyre.workspace = true
+serde_json.workspace = true
 tracing-subscriber.workspace = true
 
 [lints]

--- a/crates/setup/src/http.rs
+++ b/crates/setup/src/http.rs
@@ -1,0 +1,26 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct Error(eyre::Report);
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        let json = serde_json::json!({
+            "error": {
+                "message": self.0.to_string(),
+            },
+        });
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(json)).into_response()
+    }
+}
+
+impl From<eyre::Report> for Error {
+    fn from(error: eyre::Report) -> Self {
+        Error(error)
+    }
+}

--- a/crates/setup/src/lib.rs
+++ b/crates/setup/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod http;
+
 /// Sets up tracing.
 pub fn tracing() {
     tracing_subscriber::fmt::init();

--- a/proto/src/worker/runner.rs
+++ b/proto/src/worker/runner.rs
@@ -3,35 +3,23 @@
 //! an instance on a given worker node.
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::common::instance::{InstanceId, InstanceSpec};
-
-///
 
 /// Starts a new deploy in the system
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeployInstanceReq {
-    pub id: DeployReqId,
     pub instance_spec: InstanceSpec,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct DeployInstanceRes {
-    pub id: DeployReqId,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct DeployReqId(Uuid);
-
-/// Starts a new deploy in the system.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct DeployReq {
-    pub instance_spec: InstanceSpec,
-}
+pub struct DeployInstanceRes {}
 
 /// Stops a given service from running in the system.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TerminateReq {
     pub instance_id: InstanceId,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TerminateRes {}

--- a/worker/src/http/mod.rs
+++ b/worker/src/http/mod.rs
@@ -11,7 +11,8 @@ pub struct HttpState {
 
 pub async fn run_server(state: HttpState) {
     let app = Router::new()
-        .route("/instance/new", post(runner::new_instance))
+        .route("/instance/deploy", post(runner::deploy_instance))
+        .route("/instance/terminate", post(runner::terminate_instance))
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:6969").await.unwrap();

--- a/worker/src/http/runner/mod.rs
+++ b/worker/src/http/runner/mod.rs
@@ -1,5 +1,6 @@
-use axum::{extract::State, Json};
+use axum::{extract::State, response::IntoResponse, Json};
 use proto::worker::runner::{DeployInstanceReq, DeployInstanceRes, TerminateReq, TerminateRes};
+use reqwest::StatusCode;
 use setup::http;
 
 use crate::http::HttpState;
@@ -7,15 +8,15 @@ use crate::http::HttpState;
 pub async fn deploy_instance(
     State(state): State<HttpState>,
     Json(payload): Json<DeployInstanceReq>,
-) -> http::Result<Json<DeployInstanceRes>> {
+) -> http::Result<impl IntoResponse> {
     state.runner.deploy_instance(payload.instance_spec).await?;
-    Ok(Json(DeployInstanceRes {}))
+    Ok((StatusCode::ACCEPTED, Json(DeployInstanceRes {})))
 }
 
 pub async fn terminate_instance(
     State(state): State<HttpState>,
     Json(payload): Json<TerminateReq>,
-) -> http::Result<Json<TerminateRes>> {
+) -> http::Result<impl IntoResponse> {
     state.runner.terminate_instance(payload.instance_id).await?;
-    Ok(Json(TerminateRes {}))
+    Ok((StatusCode::ACCEPTED, Json(TerminateRes {})))
 }

--- a/worker/src/http/runner/mod.rs
+++ b/worker/src/http/runner/mod.rs
@@ -1,12 +1,21 @@
 use axum::{extract::State, Json};
-use proto::worker::runner::{DeployInstanceReq, DeployInstanceRes};
+use proto::worker::runner::{DeployInstanceReq, DeployInstanceRes, TerminateReq, TerminateRes};
+use setup::http;
 
 use crate::http::HttpState;
 
-pub async fn new_instance(
+pub async fn deploy_instance(
     State(state): State<HttpState>,
-    Json(_payload): Json<DeployInstanceReq>,
-) -> Json<DeployInstanceRes> {
-    _ = state.runner;
-    todo!();
+    Json(payload): Json<DeployInstanceReq>,
+) -> http::Result<Json<DeployInstanceRes>> {
+    state.runner.deploy_instance(payload.instance_spec).await?;
+    Ok(Json(DeployInstanceRes {}))
+}
+
+pub async fn terminate_instance(
+    State(state): State<HttpState>,
+    Json(payload): Json<TerminateReq>,
+) -> http::Result<Json<TerminateRes>> {
+    state.runner.terminate_instance(payload.instance_id).await?;
+    Ok(Json(TerminateRes {}))
 }


### PR DESCRIPTION
Completes the `http` component's routes for the `runner` methods