### PR TITLE
perf: add tests

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,7 +13,7 @@ pub struct Cli {
     #[command(subcommand)]
     cmd: Cmd,
     #[arg(short, long)]
-    ctl_addr: IpAddr,
+    ctl_addr: String,
 }
 
 #[derive(Debug, Subcommand)]
@@ -67,7 +67,7 @@ pub enum ServiceCmd {
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     let cli = Cli::parse();
-    let ctl_client = CtlClient::new(cli.ctl_addr);
+    let ctl_client = CtlClient::new(&cli.ctl_addr);
     match cli.cmd {
         Cmd::Node(cmd) => handle_node(cmd, ctl_client).await?,
         Cmd::Service(cmd) => handle_service(cmd, ctl_client).await?,

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,8 @@
             llvmPackages_16.llvm
             llvmPackages_16.bintools
             libiconv
+
+            k6
           ];
           darwinPackages = lib.optionals isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
             CoreFoundation

--- a/proto/src/clients/ctl.rs
+++ b/proto/src/clients/ctl.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, sync::Arc};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 
@@ -30,7 +30,7 @@ pub struct CtlClient {
 
 impl CtlClient {
     #[must_use]
-    pub fn new(ctl_addr: IpAddr) -> Self {
+    pub fn new(ctl_addr: &str) -> Self {
         let base_url = format!("http://{ctl_addr}:{CTL_HTTP_PORT}")
             .into_boxed_str()
             .into();

--- a/tests/perf-analysis/README.md
+++ b/tests/perf-analysis/README.md
@@ -1,0 +1,51 @@
+# Pre-steps
+
+Build the image
+
+```bash
+docker image build -t lffg/number-fact:latest ./tests/containers/number-fact
+```
+
+# Single node
+
+Start:
+
+```bash
+docker compose -f ./tests/perf-analysis/single-node/docker-compose.yml up
+```
+
+In another terminal session:
+
+```bash
+k6 run ./tests/perf-analysis/test.js
+```
+
+# Tucano multi node
+
+```bash
+docker compose -f ./tests/perf-analysis/tuc-multi-node/docker-compose.yml up
+```
+
+Ensure that ctl log shows that 3 worker nodes joined the cluster.
+
+Deploy the application:
+
+```bash
+./tucano -c localhost service deploy --id="number-fact" --image="lffg/number-fact" --public --concurrency="3"
+```
+
+Ensure that all deployments went right.
+
+In another terminal session:
+
+```bash
+k6 run ./tests/perf-analysis/test.js
+```
+
+# Tucano multi node (4x)
+
+Same steps as multi node (previous test), but different docker-compose file:
+
+```bash
+docker compose -f ./tests/perf-analysis/tuc-multi-node-4x/docker-compose.yml up
+```

--- a/tests/perf-analysis/README.md
+++ b/tests/perf-analysis/README.md
@@ -1,9 +1,25 @@
 # Pre-steps
 
+Note that if you already tested and changed some source code, you'll have to
+build without the cache. E.g.
+
+```bash
+docker compose -f ./tests/perf-analysis/<...>/docker-compose.yml build --no-cache
+```
+
 Build the image
 
 ```bash
 docker image build -t lffg/number-fact:latest ./tests/containers/number-fact
+```
+
+# Setup network
+
+The compose file uses an externally-managed Docker network named
+`tucano-cluster-net`. Make sure it is created before starting the environments.
+
+```bash
+docker network create tucano-cluster-net
 ```
 
 # Single node

--- a/tests/perf-analysis/results/single-node.txt
+++ b/tests/perf-analysis/results/single-node.txt
@@ -1,0 +1,46 @@
+❯ k6 run ./tests/perf-analysis/test.js
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ./tests/perf-analysis/test.js
+     output: -
+
+  scenarios: (100.00%) 3 scenarios, 16 max VUs, 2m0s max duration (incl. graceful stop):
+           * easyNumbers: 8 looping VUs for 30s (exec: easyNumbers, gracefulStop: 30s)
+           * mediumNumbers: 8 looping VUs for 30s (exec: mediumNumbers, startTime: 30s, gracefulStop: 30s)
+           * hardNumbers: 8 looping VUs for 30s (exec: hardNumbers, startTime: 1m0s, gracefulStop: 30s)
+
+
+     ✓ status is 200
+
+     checks.........................: 100.00% ✓ 504      ✗ 0   
+     data_received..................: 118 kB  985 B/s
+     data_sent......................: 54 kB   450 B/s
+     easy_response_times............: avg=1.2ms    min=363µs  med=997µs  max=8.11ms   p(90)=1.25ms  p(95)=1.49ms  
+     hard_response_times............: avg=15.96s   min=1.19s  med=5.6s   max=43.3s    p(90)=42.37s  p(95)=42.97s  
+     http_req_blocked...............: avg=42.24µs  min=1µs    med=3µs    max=5.58ms   p(90)=4µs     p(95)=9.54µs  
+     http_req_connecting............: avg=8.83µs   min=0s     med=0s     max=331µs    p(90)=0s      p(95)=0s      
+     http_req_duration..............: avg=790.25ms min=363µs  med=1.22ms max=43.3s    p(90)=63.4ms  p(95)=894.25ms
+       { expected_response:true }...: avg=790.25ms min=363µs  med=1.22ms max=43.3s    p(90)=63.4ms  p(95)=894.25ms
+     http_req_failed................: 0.00%   ✓ 0        ✗ 504 
+     http_req_receiving.............: avg=36.52µs  min=15µs   med=30µs   max=155µs    p(90)=61µs    p(95)=75µs    
+     http_req_sending...............: avg=41.86µs  min=5µs    med=12µs   max=5.28ms   p(90)=24.69µs p(95)=40.84µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s     med=0s     max=0s       p(90)=0s      p(95)=0s      
+     http_req_waiting...............: avg=790.17ms min=337µs  med=1.16ms max=43.3s    p(90)=63.32ms p(95)=894.21ms
+     http_reqs......................: 504     4.199773/s
+     iteration_duration.............: avg=10.32s   min=10.01s med=10.06s max=10.97s   p(90)=10.96s  p(95)=10.97s  
+     iterations.....................: 48      0.399978/s
+     medium_response_times..........: avg=61.91ms  min=630µs  med=3.21ms max=898.83ms p(90)=86.16ms p(95)=639.73ms
+     vus............................: 8       min=8      max=16
+     vus_max........................: 16      min=16     max=16
+
+
+running (2m00.0s), 00/16 VUs, 48 complete and 8 interrupted iterations
+easyNumbers   ✓ [======================================] 8 VUs  30s
+mediumNumbers ✓ [======================================] 8 VUs  30s
+hardNumbers   ✓ [======================================] 8 VUs  30s

--- a/tests/perf-analysis/single-node/docker-compose.yml
+++ b/tests/perf-analysis/single-node/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   server01:
     build: ../../containers/number-fact
-    hostname: html1
     networks:
       - tucano-cluster-net
     ports:

--- a/tests/perf-analysis/single-node/docker-compose.yml
+++ b/tests/perf-analysis/single-node/docker-compose.yml
@@ -15,4 +15,4 @@ services:
 
 networks:
   tucano-cluster-net:
-    attachable: true
+    external: true

--- a/tests/perf-analysis/test.js
+++ b/tests/perf-analysis/test.js
@@ -1,66 +1,86 @@
 // k6 run ./test.js
 
-import http from 'k6/http';
-import { check, sleep } from 'k6';
-import { Trend } from 'k6/metrics';
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend } from "k6/metrics";
 
-const API_URL = 'http://localhost:8080/factors';
+const API_URL = "http://localhost:8080/factors";
 
-const easyResponseTimes = new Trend('easy_response_times', true);
-const mediumResponseTimes = new Trend('medium_response_times', true);
-const hardResponseTimes = new Trend('hard_response_times', true);
+const easyResponseTimes = new Trend("easy_response_times", true);
+const mediumResponseTimes = new Trend("medium_response_times", true);
+const hardResponseTimes = new Trend("hard_response_times", true);
 
 export const options = {
   scenarios: {
     easyNumbers: {
-      executor: 'constant-vus',
+      executor: "constant-vus",
       vus: 8,
-      duration: '30s',
-      exec: 'easyNumbers',
+      duration: "30s",
+      exec: "easyNumbers",
     },
     mediumNumbers: {
-      executor: 'constant-vus',
+      executor: "constant-vus",
       vus: 8,
-      duration: '30s',
-      exec: 'mediumNumbers',
-      startTime: '30s',
+      duration: "30s",
+      exec: "mediumNumbers",
+      startTime: "30s",
     },
     hardNumbers: {
-      executor: 'constant-vus',
+      executor: "constant-vus",
       vus: 8,
-      duration: '30s',
-      exec: 'hardNumbers',
-      startTime: '60s',
+      duration: "30s",
+      exec: "hardNumbers",
+      startTime: "60s",
     },
   },
 };
 
 export function easyNumbers() {
   const numbers = [
-    '12345', '67890', '111213', '141516', '171819', 
-    '202122', '232425', '262728', '293031', '323334'
+    "12345",
+    "67890",
+    "111213",
+    "141516",
+    "171819",
+    "202122",
+    "232425",
+    "262728",
+    "293031",
+    "323334",
   ];
-  testAPI(numbers, 'easy');
+  testAPI(numbers, "easy");
 }
 
 export function mediumNumbers() {
   const numbers = [
-    '12345678901234567890', '98765432109876543210', '11223344556677889900',
-    '99887766554433221100', '10203040506070809000', '50607080901020304050',
-    '21436587092143658709', '13579246801357924680', '98765412309876541230',
-    '19283746501928374650'
+    "12345678901234567890",
+    "98765432109876543210",
+    "11223344556677889900",
+    "99887766554433221100",
+    "10203040506070809000",
+    "50607080901020304050",
+    "21436587092143658709",
+    "13579246801357924680",
+    "98765412309876541230",
+    "19283746501928374650",
   ];
-  testAPI(numbers, 'medium');
+  testAPI(numbers, "medium");
 }
 
 export function hardNumbers() {
   const numbers = [
-    '123456789012345677777', '987654321098765432777', '112233445566778899075',
-    '998877665544332211057', '102030405060708090057', '506070809010203040575',
-    '214365870921436587577', '135792468013579246875', '9876541230987654123775',
-    '19283746501928374655705'
+    "123456789012345677777",
+    "987654321098765432777",
+    "112233445566778899075",
+    "998877665544332211057",
+    "102030405060708090057",
+    "506070809010203040575",
+    "214365870921436587577",
+    "135792468013579246875",
+    "9876541230987654123775",
+    "19283746501928374655705",
   ];
-  testAPI(numbers, 'hard');
+  testAPI(numbers, "hard");
 }
 
 function testAPI(numbers, tag) {
@@ -72,15 +92,18 @@ function testAPI(numbers, tag) {
 
   for (const number of numbers) {
     const res = http.get(`${API_URL}?number=${number}`, {
+      headers: {
+        Host: "number-fact",
+      },
       tags: { scenario: tag },
     });
 
     check(res, {
-      'status is 200': (r) => r.status === 200,
+      "status is 200": (r) => r.status === 200,
     });
 
     trends[tag].add(res.timings.duration);
 
-    sleep(1); 
+    sleep(1);
   }
 }

--- a/tests/perf-analysis/tuc-multi-node-4x/docker-compose.yml
+++ b/tests/perf-analysis/tuc-multi-node-4x/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  ctl:
+    build:
+      context: ../../.. # repo root
+      dockerfile: ./dockerfiles/node.dockerfile
+      args:
+        CRATE: ctl
+    entrypoint:
+      - /usr/local/bin/ctl
+    networks: [tucano-cluster-net]
+    ports:
+      - "8080:8080" # balancer
+      - "7070:7070" # http
+    environment:
+      RUST_LOG: info,ctl=trace
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: "512MB"
+
+  worker1: &w1
+    depends_on: [ctl]
+    build:
+      context: ../../.. # repo root
+      dockerfile: ./dockerfiles/node.dockerfile
+      args:
+        CRATE: worker
+    entrypoint:
+      - /usr/local/bin/worker
+      - -c=ctl
+    networks:
+      - tucano-cluster-net
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      RUST_LOG: info,worker=trace
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: "512MB"
+
+  worker2:
+    <<: *w1
+  worker3:
+    <<: *w1
+
+networks:
+  tucano-cluster-net:
+    attachable: true

--- a/tests/perf-analysis/tuc-multi-node-4x/docker-compose.yml
+++ b/tests/perf-analysis/tuc-multi-node-4x/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     entrypoint:
       - /usr/local/bin/worker
       - -c=ctl
+      - --use-docker-network=tucano-cluster-net
     networks:
       - tucano-cluster-net
     volumes:
@@ -48,4 +49,4 @@ services:
 
 networks:
   tucano-cluster-net:
-    attachable: true
+    external: true

--- a/tests/perf-analysis/tuc-multi-node/docker-compose.yml
+++ b/tests/perf-analysis/tuc-multi-node/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     entrypoint:
       - /usr/local/bin/worker
       - -c=ctl
+      - --use-docker-network=tucano-cluster-net
     networks:
       - tucano-cluster-net
     volumes:
@@ -48,4 +49,4 @@ services:
 
 networks:
   tucano-cluster-net:
-    attachable: true
+    external: true

--- a/tests/perf-analysis/tuc-multi-node/docker-compose.yml
+++ b/tests/perf-analysis/tuc-multi-node/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  ctl:
+    build:
+      context: ../../.. # repo root
+      dockerfile: ./dockerfiles/node.dockerfile
+      args:
+        CRATE: ctl
+    entrypoint:
+      - /usr/local/bin/ctl
+    networks: [tucano-cluster-net]
+    ports:
+      - "8080:8080" # balancer
+      - "7070:7070" # http
+    environment:
+      RUST_LOG: info,ctl=trace
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: "128MB"
+
+  worker1: &w1
+    depends_on: [ctl]
+    build:
+      context: ../../.. # repo root
+      dockerfile: ./dockerfiles/node.dockerfile
+      args:
+        CRATE: worker
+    entrypoint:
+      - /usr/local/bin/worker
+      - -c=ctl
+    networks:
+      - tucano-cluster-net
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      RUST_LOG: info,worker=trace
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: "128MB"
+
+  worker2:
+    <<: *w1
+  worker3:
+    <<: *w1
+
+networks:
+  tucano-cluster-net:
+    attachable: true

--- a/tucano
+++ b/tucano
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-cargo build -q
+cargo build
 ./target/debug/cli "$@"

--- a/worker/src/args.rs
+++ b/worker/src/args.rs
@@ -1,4 +1,4 @@
-use std::{net::IpAddr, time::Duration};
+use std::time::Duration;
 
 use clap::Parser;
 
@@ -6,7 +6,7 @@ use clap::Parser;
 pub struct WorkerArgs {
     /// Controller's HTTP address.
     #[arg(short, long)]
-    pub ctl_addr: IpAddr,
+    pub ctl_addr: String,
 
     /// Interval at which metrics are pushed to the controller.
     ///

--- a/worker/src/args.rs
+++ b/worker/src/args.rs
@@ -8,6 +8,15 @@ pub struct WorkerArgs {
     #[arg(short, long)]
     pub ctl_addr: String,
 
+    /// Whether the worker should run in a Docker-networking aware context.
+    ///
+    /// If set, must specify the name of the Docker network.
+    ///
+    /// In general, this option is desirable when executing all Tucano nodes
+    /// in a single host via Docker containers.
+    #[arg(long)]
+    pub use_docker_network: Option<String>,
+
     /// Interval at which metrics are pushed to the controller.
     ///
     /// Notice that this interval MUST be smaller than the value configured for

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     let args = Arc::new(WorkerArgs::parse());
     info!(?args, "started worker");
 
-    let ctl_client = CtlClient::new(args.ctl_addr);
+    let ctl_client = CtlClient::new(&args.ctl_addr);
 
     let proxy_listener = mk_listener(ANY_IP, WORKER_PROXY_PORT).await?;
     let http_listener = mk_listener(ANY_IP, WORKER_HTTP_PORT).await?;

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
 
     let mut bag = JoinSet::new();
 
-    let (proxy_state, proxy_handle) = ProxyState::new();
+    let (proxy_state, proxy_handle) = ProxyState::new(&args);
     bag.spawn(async move {
         let app = proxy::proxy.with_state(proxy_state);
         info!("worker proxy listening at {ANY_IP}:{WORKER_PROXY_PORT}");
@@ -49,7 +49,8 @@ async fn main() -> Result<()> {
     });
 
     let docker = Arc::new(Docker::connect_with_defaults().unwrap());
-    let (runner, runner_handle) = Runner::new(docker, ctl_client.clone(), proxy_handle);
+    let (runner, runner_handle) =
+        Runner::new(args.clone(), docker, ctl_client.clone(), proxy_handle);
     bag.spawn(async move {
         runner.run().await;
     });


### PR DESCRIPTION
Multi node tests aren't working yet.

Since we're running the performance tests in a docker context (i.e., the controller and each worker live in docker containers), the workers' proxy can't reach the underlying application container (created by Tucano) since they're in effectively different (docker) networks.

https://github.com/esfericos/tucano/blob/18423fe6c1baac67c0f05832f628a8f35fe11cf7/worker/src/proxy.rs#L46

This works in a "normal" Tucano setup because in this case the worker is in fact the "host" (in the docker networking point of view). When Tucano creates the underlying application container and publishes (to the host) the chosen port, the worker can access it through `127.0.0.1:{port}`.

However, when a worker is running through docker (as we're doing in this performance test setup), it isn't the _host_ anymore, not being able to access the underlying application container through `127.0.0.1` anymore.